### PR TITLE
fix: Unify post link spacing and fix grid gaps on Chrome/Safari

### DIFF
--- a/components/post-link.module.scss
+++ b/components/post-link.module.scss
@@ -4,7 +4,7 @@
 
 .post-link {
   width: 100%;
-  height: 150px;
+  min-height: 150px;
   position: relative;
 
   display: flex;
@@ -18,7 +18,7 @@
 
   @include touch {
     flex-direction: row;
-    height: 170px;
+    min-height: 170px;
     justify-content: center;
 
     .cta {

--- a/components/post-link.module.scss
+++ b/components/post-link.module.scss
@@ -61,6 +61,6 @@
   }
 
   &:last-of-type {
-    margin-bottom: 1em;
+    margin-bottom: 1.5em;
   }
 }

--- a/pages/blog.module.scss
+++ b/pages/blog.module.scss
@@ -9,7 +9,7 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-gap: 1.5em;
-  margin-top: 2em;
+  margin-top: 1.5em;
 
   @include touch {
     grid-template-columns: 1fr;

--- a/pages/blog.module.scss
+++ b/pages/blog.module.scss
@@ -9,7 +9,6 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-gap: 1.5em;
-  grid-auto-rows: 33%;
   margin-top: 2em;
 
   @include touch {


### PR DESCRIPTION
Yo @maferland ! Long time no see

Stumbled upon your website, looks super cool

Found a visual glitch on post links in Chrome and Safari, not sure if you were aware of it. Took the 15 minutes to fix it.

Defining the preferred row height on the grid conflicted with the defined height of the post links themselves.

## What it looked like in Chrome/Safari

### Desktop

![Screen Shot 2020-09-13 at 17 49 40](https://user-images.githubusercontent.com/5920450/93029531-82458280-f5e9-11ea-814d-8e122d796d48.png)

### Mobile

![Screen Shot 2020-09-13 at 17 51 14](https://user-images.githubusercontent.com/5920450/93029559-ba4cc580-f5e9-11ea-8837-f084a4ba38a2.png)

## What it looks like now:

### Desktop

![Screen Shot 2020-09-13 at 18 07 35](https://user-images.githubusercontent.com/5920450/93029802-026ce780-f5ec-11ea-87a9-e960d9cd9abe.png)

### Mobile

![Screen Shot 2020-09-13 at 18 07 58](https://user-images.githubusercontent.com/5920450/93029811-0f89d680-f5ec-11ea-9063-b961a5e41831.png)

Cheers dude! 🍺  